### PR TITLE
fixed plugin not stopping service by updating altbeacon lib

### DIFF
--- a/src/android/cordova-plugin-ibeacon.gradle
+++ b/src/android/cordova-plugin-ibeacon.gradle
@@ -3,7 +3,7 @@ repositories{
 }
 
 dependencies {
-    compile 'org.altbeacon:android-beacon-library:2.15.2'
+    implementation 'org.altbeacon:android-beacon-library:2.16.1'
 }
 
 android {


### PR DESCRIPTION
updated altbeacon lib to 2.16.1
fixed 'compile' keyword with 'implementation'